### PR TITLE
Fix cmake error in ftl

### DIFF
--- a/src/libdev/ftl/CMakeLists.txt
+++ b/src/libdev/ftl/CMakeLists.txt
@@ -15,4 +15,5 @@ set(FTL_SOURCES
     seripmap.itp
 )
 
-add_library(ftl INTERFACE ${FTL_SOURCES})
+add_library(ftl INTERFACE)
+target_sources(ftl INTERFACE ${FTL_SOURCES})


### PR DESCRIPTION
Fix error:
```
CMake Error at src/libdev/ftl/CMakeLists.txt:18 (add_library):
  add_library INTERFACE library requires no source arguments.
```